### PR TITLE
Fix default font on Windows

### DIFF
--- a/Theme (Windows).css
+++ b/Theme (Windows).css
@@ -1,6 +1,6 @@
 * {
 	/*font-family: "Roboto Bold"*/
-	font-family: Roboto;
+	font-family: "Roboto Bold", Roboto, Arial;
 	font-weight: bold;
 }
 

--- a/Theme (Windows).css
+++ b/Theme (Windows).css
@@ -1,5 +1,7 @@
 * {
-	font-family: "Roboto Bold";
+	/*font-family: "Roboto Bold"*/
+	font-family: Roboto;
+	font-weight: bold;
 }
 
 .locationbar {


### PR DESCRIPTION
I was a MacOS user, and the default font of fman used to work fine for me. I switched to Windows lately, but the font was not loaded; instead, fman showed me a very ugly default font. I checked the original [fman-users/Core](https://github.com/fman-users/Core) repo and used the "Theme (Windows).css" as my template for custom CSS, and I found that Roboto works, whereas "Roboto Bold" doesn't (because Qt misinterprets it as the font's *name*, not the *name* and *style*); then I tried "font-weight: bold" with "font-family: Roboto" and achieved desired results. See images below.

![with Roboto Bold](https://i.imgur.com/kb6v8SB.png)
![with Roboto and font-weight:bold](https://i.imgur.com/zGIbAat.png)